### PR TITLE
Add bottom effect rendering support

### DIFF
--- a/src/client/thing.h
+++ b/src/client/thing.h
@@ -133,6 +133,7 @@ public:
     bool isWrapable() { return rawGetThingType()->isWrapable(); }
     bool isUnwrapable() { return rawGetThingType()->isUnwrapable(); }
     bool isTopEffect() { return rawGetThingType()->isTopEffect(); }
+    bool isBottomEffect() { return rawGetThingType()->isBottomEffect(); }
     MarketData getMarketData() { return rawGetThingType()->getMarketData(); }
 
     void hide() { m_hidden = true; }

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -47,6 +47,7 @@ ThingType::ThingType()
     m_layers = 0;
     m_elevation = 0;
     m_opacity = 1.0f;
+    m_bottomEffect = false;
 }
 
 void ThingType::serialize(const FileStreamPtr& fin)
@@ -486,6 +487,8 @@ void ThingType::unserializeOtml(const OTMLNodePtr& node)
                 m_attribs.set(ThingAttrFullGround, true);
             else
                 m_attribs.remove(ThingAttrFullGround);
+        } else if(node2->tag() == "bottom-effect") {
+            m_bottomEffect = node2->value<bool>();
         }
     }
 }

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -257,6 +257,7 @@ public:
     bool isWrapable() { return m_attribs.has(ThingAttrWrapable); }
     bool isUnwrapable() { return m_attribs.has(ThingAttrUnwrapable); }
     bool isTopEffect() { return m_attribs.has(ThingAttrTopEffect); }
+    bool isBottomEffect() { return m_bottomEffect; }
     bool hasBones() { return m_attribs.has(ThingAttrBones); }
 
     std::vector<int> getSprites() { return m_spritesIndex; }
@@ -290,6 +291,7 @@ private:
     int m_elevation;
     float m_opacity;
     std::string m_customImage;
+    bool m_bottomEffect = false;
 
     std::vector<int> m_spritesIndex;
     std::vector<TexturePtr> m_textures;

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -161,6 +161,17 @@ void Tile::drawTop(const Point& dest, LightView* lightView)
     if (m_topDraws++ < m_topCorrection)
         return;
 
+    // bottom effects
+    int effectLimit = std::min<int>((int)m_effects.size() - 1, g_adaptiveRenderer.effetsLimit());
+    for (int i = effectLimit; i >= 0; --i) {
+        if (m_effects[i]->isHidden() || !m_effects[i]->isBottomEffect())
+            continue;
+        m_effects[i]->draw(dest - m_drawElevation * g_sprites.getOffsetFactor(),
+                           m_position.x - g_map.getCentralPosition().x,
+                           m_position.y - g_map.getCentralPosition().y,
+                           true, lightView);
+    }
+
     // walking creatures
     for (const CreaturePtr& creature : m_walkingCreatures) {
         if (creature->isHidden())
@@ -187,9 +198,12 @@ void Tile::drawTop(const Point& dest, LightView* lightView)
     // effects
     limit = std::min<int>((int)m_effects.size() - 1, g_adaptiveRenderer.effetsLimit());
     for (int i = limit; i >= 0; --i) {
-        if (m_effects[i]->isHidden())
+        if (m_effects[i]->isHidden() || m_effects[i]->isBottomEffect())
             continue;
-        m_effects[i]->draw(dest - m_drawElevation * g_sprites.getOffsetFactor(), m_position.x - g_map.getCentralPosition().x, m_position.y - g_map.getCentralPosition().y, true, lightView);
+        m_effects[i]->draw(dest - m_drawElevation * g_sprites.getOffsetFactor(),
+                           m_position.x - g_map.getCentralPosition().x,
+                           m_position.y - g_map.getCentralPosition().y,
+                           true, lightView);
     }
 
     // top


### PR DESCRIPTION
## Summary
- add a `bottomEffect` flag to thing types parsed from OTML
- expose `isBottomEffect` in Thing/ThingType classes
- draw bottom effects before creatures in `Tile::drawTop`

## Testing
- `cmake -S . -B build` *(fails: Could NOT find LuaJIT, BOOST, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6842a0f176d083228659c5a454c874f1