### PR TITLE
Fix color wrap update bug

### DIFF
--- a/src/framework/graphics/bitmapfont.cpp
+++ b/src/framework/graphics/bitmapfont.cpp
@@ -388,8 +388,7 @@ void BitmapFont::updateColors(std::vector<std::pair<int, Color>>* colors, int po
 {
     if (!colors) return;
     for (auto& it : *colors) {
-        if (it.first > pos) {
+        if (it.first >= pos)
             it.first += newTextLen;
-        }
     }
 }


### PR DESCRIPTION
## Summary
- fix text color indices shifting when wrapping text

## Testing
- `cmake ..` *(fails: Could NOT find LuaJIT)*

------
https://chatgpt.com/codex/tasks/task_e_6843fe7e284483228ee95c82fb722cb6