### PR TITLE
Add default cursor support

### DIFF
--- a/data/cursors/cursors.otml
+++ b/data/cursors/cursors.otml
@@ -14,3 +14,7 @@ Cursors
   pointer:
     image: pointer
     hot-spot: 5 0
+  # Cursor used as the default when no custom cursor is active
+  default:
+    image: pointer
+    hot-spot: 5 0

--- a/src/framework/CMakeLists.txt
+++ b/src/framework/CMakeLists.txt
@@ -387,7 +387,7 @@ if(FRAMEWORK_GRAPHICS)
             message(STATUS "Windows console: OFF")
         endif()
     elseif(NOT WASM)
-        set(framework_LIBRARIES ${framework_LIBRARIES} X11)
+        set(framework_LIBRARIES ${framework_LIBRARIES} X11 Xcursor)
     endif()
 
     set(framework_SOURCES ${framework_SOURCES}

--- a/src/framework/input/mouse.cpp
+++ b/src/framework/input/mouse.cpp
@@ -44,10 +44,17 @@ void Mouse::loadCursors(std::string filename)
         OTMLDocumentPtr doc = OTMLDocument::parse(filename);
         OTMLNodePtr cursorsNode = doc->at("Cursors");
 
-        for(const OTMLNodePtr& cursorNode : cursorsNode->children())
+        for(const OTMLNodePtr& cursorNode : cursorsNode->children()) {
             addCursor(cursorNode->tag(),
                       stdext::resolve_path(cursorNode->valueAt("image"), cursorNode->source()),
                       cursorNode->valueAt<Point>("hot-spot"));
+            if(cursorNode->tag() == "default")
+                setDefaultCursor("default");
+        }
+
+        auto it = m_cursors.find(m_defaultCursor);
+        if(it != m_cursors.end())
+            g_window.setMouseCursor(it->second);
     } catch(stdext::exception& e) {
         g_logger.error(stdext::format("unable to load cursors file: %s", e.what()));
     }
@@ -113,8 +120,13 @@ void Mouse::popCursor(const std::string& name)
 
     if(m_cursorStack.size() > 0)
         g_window.setMouseCursor(m_cursorStack.back());
-    else
-        g_window.restoreMouseCursor();
+    else {
+        auto it = m_cursors.find(m_defaultCursor);
+        if(it != m_cursors.end())
+            g_window.setMouseCursor(it->second);
+        else
+            g_window.restoreMouseCursor();
+    }
 }
 
 bool Mouse::isCursorChanged()

--- a/src/framework/input/mouse.h
+++ b/src/framework/input/mouse.h
@@ -36,11 +36,14 @@ public:
     void pushCursor(const std::string& name);
     void popCursor(const std::string& name);
     bool isCursorChanged();
+    void setDefaultCursor(const std::string& name) { m_defaultCursor = name; }
+    std::string getDefaultCursor() { return m_defaultCursor; }
     bool isPressed(Fw::MouseButton mouseButton);
 
 private:
     std::map<std::string, int> m_cursors;
     std::deque<int> m_cursorStack;
+    std::string m_defaultCursor;
     std::mutex m_mutex;
 };
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -20,6 +20,10 @@
         "openssl",
         "openal-soft",
         "glew",
+        {
+            "name": "libxcursor",
+            "platform": "!windows"
+        },
         "luajit",
         {
             "name": "opengl",


### PR DESCRIPTION
## Summary
- allow specifying a "default" cursor in `cursors.otml`
- use the custom cursor when the stack is empty
- document the new option in the OTML file
- apply the default cursor as soon as cursors are loaded

## Testing
- `cmake -S . -B build` *(fails: Could NOT find LIBZIP, Boost, LuaJIT)*

------
https://chatgpt.com/codex/tasks/task_e_6847203507f8832299b8502a00231a0e