### PR TITLE
Add creature scaling via opcode

### DIFF
--- a/src/client/creature.h
+++ b/src/client/creature.h
@@ -198,6 +198,9 @@ public:
     void setProgressBar(uint32 duration, bool ltr);
     void updateProgressBar(uint32 duration, bool ltr);
 
+    void setScale(float scale, uint16_t duration = 0);
+    float getScale() const;
+
 protected:
     virtual void updateWalkAnimation(uint8 totalPixelsWalked);
     virtual void updateWalkOffset(uint8 totalPixelsWalked, bool inNextFrame = false);
@@ -276,6 +279,13 @@ protected:
     float m_jumpDuration = 0;
     PointF m_jumpOffset;
     Timer m_jumpTimer;
+
+    struct {
+        Timer timer;
+        uint16_t duration{ 0 };
+        float start{ 1.f };
+        float target{ 1.f };
+    } m_scale;
 
     // for bot
     StaticTextPtr m_text;

--- a/src/client/luafunctions_client.cpp
+++ b/src/client/luafunctions_client.cpp
@@ -554,6 +554,8 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Creature>("setTitle", &Creature::setTitle);
     g_lua.bindClassMemberFunction<Creature>("clearTitle", &Creature::clearTitle);
     g_lua.bindClassMemberFunction<Creature>("getTitle", &Creature::getTitle);
+    g_lua.bindClassMemberFunction<Creature>("setScale", &Creature::setScale);
+    g_lua.bindClassMemberFunction<Creature>("getScale", &Creature::getScale);
     g_lua.bindClassMemberFunction<Creature>("isTimedSquareVisible", &Creature::isTimedSquareVisible);
     g_lua.bindClassMemberFunction<Creature>("getTimedSquareColor", &Creature::getTimedSquareColor);
     g_lua.bindClassMemberFunction<Creature>("isStaticSquareVisible", &Creature::isStaticSquareVisible);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -34,6 +34,7 @@
 #include "luavaluecasts_client.h"
 #include <framework/core/eventdispatcher.h>
 #include <framework/util/extras.h>
+#include <framework/stdext/cast.h>
 #include <framework/stdext/string.h>
 
 void ProtocolGame::parseMessage(const InputMessagePtr& msg)
@@ -3095,7 +3096,16 @@ void ProtocolGame::parseExtendedOpcode(const InputMessagePtr& msg)
 
     if (opcode == 0)
         m_enableSendExtendedOpcode = true;
-    else
+    else if (opcode == 1) {
+        auto values = stdext::split(buffer, ",");
+        if (values.size() >= 2) {
+            uint32 id = stdext::unsafe_cast<uint32>(values[0]);
+            float scale = stdext::unsafe_cast<float>(values[1], 1.f);
+            uint16_t duration = values.size() >= 3 ? stdext::unsafe_cast<uint16_t>(values[2], 0) : 0;
+            if (CreaturePtr creature = g_map.getCreatureById(id))
+                creature->setScale(scale, duration);
+        }
+    } else
         callLuaField("onExtendedOpcode", opcode, buffer);
 }
 


### PR DESCRIPTION
## Summary
- add animated scaling logic to `Creature`
- support duration when setting scale via opcode
- anchor scaled outfits without breaking bottom-right alignment

## Testing
- `cmake -S . -B build` *(fails: Unable to find Boost and LuaJIT)*

------
https://chatgpt.com/codex/tasks/task_e_684107c1b6948322b93248c1d301033e