### PR TITLE
Remove obsolete button helpers

### DIFF
--- a/data/styles/20-popupmenus.otui
+++ b/data/styles/20-popupmenus.otui
@@ -16,6 +16,11 @@ PopupMenuButton < UIButton
   $disabled:
     color: #555555
 
+PopupMenuIconButton < PopupMenuButton
+  icon-align: left
+  icon-offset-x: 4
+  icon-size: 16 16
+
 PopupMenuShortcutLabel < Label
   font: verdana-11px-antialised
   text-align: right

--- a/data/styles/20-topmenu.otui
+++ b/data/styles/20-topmenu.otui
@@ -29,7 +29,7 @@ TopMenu < UIWindow
   draggable: true
   phantom: false
 
-  UIWidget
+  TopMenuButtonsPanel
     id: buttonsPanel
     anchors.fill: parent
     margin: 20

--- a/data/styles/20-topmenu.otui
+++ b/data/styles/20-topmenu.otui
@@ -12,7 +12,6 @@ TopMenuButtonsPanel < Panel
   layout:
     type: horizontalBox
     spacing: 4
-    fit-children: true
   padding: 6 4
 
 

--- a/layouts/retro/styles/20-popupmenus.otui
+++ b/layouts/retro/styles/20-popupmenus.otui
@@ -16,6 +16,11 @@ PopupMenuButton < UIButton
   $disabled:
     color: #777777
 
+PopupMenuIconButton < PopupMenuButton
+  icon-align: left
+  icon-offset-x: 4
+  icon-size: 16 16
+
 PopupMenuShortcutLabel < Label
   font: verdana-11px-rounded
   text-align: right

--- a/layouts/retro/styles/20-topmenu.otui
+++ b/layouts/retro/styles/20-topmenu.otui
@@ -97,35 +97,10 @@ TopMenu < TopMenuPanel
     text-auto-resize: true
 
   TopMenuButtonsPanel
-    id: rightButtonsPanel
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
-    anchors.left: prev.right
-
-  TopMenuButtonsPanel
-    id: rightGameButtonsPanel
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
-    anchors.left: prev.right
-    visible: false
-
-  Label
-    id: onlineLabel
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
-    anchors.horizontalCenter: parent.horizontalCenter
-    text-align: center
-    text-auto-resize: true
-
-  TopMenuButtonsPanel
-    id: leftButtonsPanel
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
-    anchors.right: parent.right
-
-  TopMenuButtonsPanel
-    id: leftGameButtonsPanel
-    anchors.top: parent.top
-    anchors.bottom: parent.bottom
-    anchors.right: prev.left
-    visible: false
+    id: buttonsPanel
+    anchors.fill: parent
+    margin: 20
+    border-width: 1
+    border-color: #A68D73
+    background-color: #1A1A1A80
+    phantom: true

--- a/layouts/retro/styles/20-topmenu.otui
+++ b/layouts/retro/styles/20-topmenu.otui
@@ -51,7 +51,6 @@ TopMenuButtonsPanel < Panel
   layout:
     type: horizontalBox
     spacing: 4
-    fit-children: true
   padding: 6 4
 
 TopMenuPanel < Panel

--- a/modules/game_battle/battle.lua
+++ b/modules/game_battle/battle.lua
@@ -17,7 +17,7 @@ local ages = {}
 
 function init()  
   g_ui.importStyle('battlebutton')
-  battleButton = modules.client_topmenu.addRightGameToggleButton('battleButton', tr('Battle') .. ' (Ctrl+B)', '/images/topbuttons/battle', toggle, false, 2)
+  battleButton = modules.client_topmenu.addCategoryListing('battleButton', tr('Battle') .. ' (Ctrl+B)', '/images/topbuttons/battle', toggle, "HUD", 1)
   battleButton:setOn(true)
   battleWindow = g_ui.loadUI('battle', modules.game_interface.getRightPanel())
 

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -59,8 +59,8 @@ function init()
   gameLeftActions = gameRootPanel:getChildById('gameLeftActions')
   connect(gameLeftPanel, { onVisibilityChange = onLeftPanelVisibilityChange })
 
-  logoutButton = modules.client_topmenu.addLeftButton('logoutButton', tr('Exit'),
-    '/images/topbuttons/logout', tryLogout, true)
+  logoutButton = modules.client_topmenu.addOwnListing('logoutButton', tr('Exit'),
+    '/images/topbuttons/logout', tryLogout, 1)
 
 
   gameRightPanels:addChild(g_ui.createWidget('GameSidePanel'))


### PR DESCRIPTION
## Summary
- clean up 20-topmenu styles to use a single buttons panel
- remove legacy button-adding helpers from `topmenu.lua`
- add a simplified `createButton` helper

## Testing
- `cmake . -DCMAKE_BUILD_TYPE=Release` *(fails: Boost and LuaJIT not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884398882ac8322ba0f07944602e71a