### PR TITLE
Add configurable magic effects speed

### DIFF
--- a/modules/client_options/graphics.otui
+++ b/modules/client_options/graphics.otui
@@ -74,6 +74,19 @@ OptionPanel
     margin-top: 3
     minimum: 0
     maximum: 100
+
+  Label
+    id: effectsSpeedLabel
+    margin-top: 6
+    @onSetup: |
+      local value = modules.client_options.getOption('effectsSpeed')
+      self:setText(tr('Effects speed: %s ms', value))
+
+  OptionScrollbar
+    id: effectsSpeed
+    margin-top: 3
+    minimum: 50
+    maximum: 100
   
   Label
     id: tips

--- a/modules/client_options/options.lua
+++ b/modules/client_options/options.lua
@@ -70,6 +70,8 @@ local defaultOptions = {
   antialiasing = true,
   floorShadow = true,
 
+  effectsSpeed = 75,
+
   autoSwitchPreset = true
 }
 
@@ -659,6 +661,9 @@ function updateValues(key, value)
     else
       g_game.disableFeature(GameDrawFloorShadow)
     end
+  elseif key == "effectsSpeed" then
+    graphicsPanel:getChildById("effectsSpeedLabel"):setText(tr("Effects speed: %s ms", value))
+    Effect.setTicksPerFrame(value)
   elseif key == "chatMode" then
     Keybind.setChatMode(value)
     local check = value ~= CHAT_MODE.ON and true or false

--- a/modules/client_options/options.lua
+++ b/modules/client_options/options.lua
@@ -663,7 +663,7 @@ function updateValues(key, value)
     end
   elseif key == "effectsSpeed" then
     graphicsPanel:getChildById("effectsSpeedLabel"):setText(tr("Effects speed: %s ms", value))
-    Effect.setTicksPerFrame(value)
+    g_game.setEffectTicksPerFrame(value)
   elseif key == "chatMode" then
     Keybind.setChatMode(value)
     local check = value ~= CHAT_MODE.ON and true or false

--- a/src/client/effect.cpp
+++ b/src/client/effect.cpp
@@ -26,6 +26,19 @@
 #include <framework/core/eventdispatcher.h>
 #include <framework/util/extras.h>
 #include <framework/stdext/fastrand.h>
+#include <algorithm>
+
+int Effect::TICKS_PER_FRAME = 75;
+
+void Effect::setTicksPerFrame(int ticks)
+{
+    TICKS_PER_FRAME = std::max(1, ticks);
+}
+
+int Effect::getTicksPerFrame()
+{
+    return TICKS_PER_FRAME;
+}
 
 void Effect::draw(const Point& dest, int offsetX, int offsetY, bool animate, LightView* lightView)
 {
@@ -38,7 +51,7 @@ void Effect::draw(const Point& dest, int offsetX, int offsetY, bool animate, Lig
             m_animationPhase = std::max<int>(0, rawGetThingType()->getAnimator()->getPhaseAt(m_animationTimer, m_randomSeed, m_animationPhase));
         } else {
             // hack to fix some animation phases duration, currently there is no better solution
-            int ticks = EFFECT_TICKS_PER_FRAME;
+            int ticks = TICKS_PER_FRAME;
             if (m_id == 33) {
                 ticks <<= 2;
             }
@@ -67,7 +80,7 @@ void Effect::onAppear()
         m_randomSeed = (uint32_t)stdext::fastrand();
         duration = getThingType()->getAnimator() ? getThingType()->getAnimator()->getTotalDuration(m_randomSeed) : 1000;
     } else {
-        duration = EFFECT_TICKS_PER_FRAME;
+        duration = TICKS_PER_FRAME;
 
         // hack to fix some animation phases duration, currently there is no better solution
         if(m_id == 33) {

--- a/src/client/effect.cpp
+++ b/src/client/effect.cpp
@@ -28,7 +28,7 @@
 #include <framework/stdext/fastrand.h>
 #include <algorithm>
 
-int Effect::TICKS_PER_FRAME = 75;
+int Effect::TICKS_PER_FRAME = Effect::DEFAULT_EFFECT_TICKS;
 
 void Effect::setTicksPerFrame(int ticks)
 {
@@ -47,8 +47,14 @@ void Effect::draw(const Point& dest, int offsetX, int offsetY, bool animate, Lig
 
     if(animate) {
         if(g_game.getFeature(Otc::GameEnhancedAnimations) && rawGetThingType()->getAnimator()) {
+            // adjust timer ticks so animations respect the configured frame speed
+            float scale = static_cast<float>(Effect::DEFAULT_EFFECT_TICKS) / TICKS_PER_FRAME;
+
+            Timer timer;
+            timer.adjust(-static_cast<int>(m_animationTimer.ticksElapsed() * scale));
+
             // This requires a separate getPhaseAt method as using getPhase would make all magic effects use the same phase regardless of their appearance time
-            m_animationPhase = std::max<int>(0, rawGetThingType()->getAnimator()->getPhaseAt(m_animationTimer, m_randomSeed, m_animationPhase));
+            m_animationPhase = std::max<int>(0, rawGetThingType()->getAnimator()->getPhaseAt(timer, m_randomSeed, m_animationPhase));
         } else {
             // hack to fix some animation phases duration, currently there is no better solution
             int ticks = TICKS_PER_FRAME;
@@ -79,6 +85,7 @@ void Effect::onAppear()
     if(g_game.getFeature(Otc::GameEnhancedAnimations)) {
         m_randomSeed = (uint32_t)stdext::fastrand();
         duration = getThingType()->getAnimator() ? getThingType()->getAnimator()->getTotalDuration(m_randomSeed) : 1000;
+        duration = static_cast<int>(duration * TICKS_PER_FRAME / Effect::DEFAULT_EFFECT_TICKS);
     } else {
         duration = TICKS_PER_FRAME;
 

--- a/src/client/effect.h
+++ b/src/client/effect.h
@@ -30,13 +30,14 @@
 // @bindclass
 class Effect : public Thing
 {
-    enum {
-        EFFECT_TICKS_PER_FRAME = 75
-    };
+
 
 public:
     void draw(const Point& dest, bool animate = true, LightView* lightView = nullptr) override {}
     void draw(const Point& dest, int offsetX = 0, int offsetY = 0, bool animate = true, LightView* lightView = nullptr);
+
+    static void setTicksPerFrame(int ticks);
+    static int getTicksPerFrame();
     
     void setId(uint32 id) override;
     uint32 getId() override { return m_id; }
@@ -55,6 +56,8 @@ private:
     Timer m_animationTimer;
     int m_animationPhase = 0;
     uint32 m_randomSeed;
+
+    static int TICKS_PER_FRAME;
 };
 
 #endif

--- a/src/client/effect.h
+++ b/src/client/effect.h
@@ -57,6 +57,7 @@ private:
     int m_animationPhase = 0;
     uint32 m_randomSeed;
 
+    static constexpr int DEFAULT_EFFECT_TICKS = 75;
     static int TICKS_PER_FRAME;
 };
 

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -33,6 +33,7 @@
 #include "localplayer.h"
 #include "outfit.h"
 #include <framework/core/timer.h>
+#include <algorithm>
 
 #include <bitset>
 
@@ -390,6 +391,13 @@ public:
         return m_transferableCoins;
     }
 
+    void setEffectTicksPerFrame(int ticks)
+    {
+        m_effectTicksPerFrame = std::max(1, ticks);
+        Effect::setTicksPerFrame(m_effectTicksPerFrame);
+    }
+    int getEffectTicksPerFrame() { return m_effectTicksPerFrame; }
+
     void setMaxPreWalkingSteps(uint value) { m_maxPreWalkingSteps = value; }
     uint getMaxPreWalkingSteps() { return m_maxPreWalkingSteps; }
 
@@ -473,6 +481,7 @@ private:
     int m_clientCustomOs;
     int m_coins;
     int m_transferableCoins;
+    int m_effectTicksPerFrame = Effect::DEFAULT_EFFECT_TICKS;
 
     bool m_showRealDirection = false;
     bool m_ignoreServerDirection = true;

--- a/src/client/luafunctions_client.cpp
+++ b/src/client/luafunctions_client.cpp
@@ -698,6 +698,8 @@ void Client::registerLuaFunctions()
     g_lua.registerClass<Effect, Thing>();
     g_lua.bindClassStaticFunction<Effect>("create", []{ return std::make_shared<Effect>(); });
     g_lua.bindClassMemberFunction<Effect>("setId", &Effect::setId);
+    g_lua.bindClassStaticFunction<Effect>("setTicksPerFrame", &Effect::setTicksPerFrame);
+    g_lua.bindClassStaticFunction<Effect>("getTicksPerFrame", &Effect::getTicksPerFrame);
 
     g_lua.registerClass<Missile, Thing>();
     g_lua.bindClassStaticFunction<Missile>("create", []{ return std::make_shared<Missile>(); });

--- a/src/client/luafunctions_client.cpp
+++ b/src/client/luafunctions_client.cpp
@@ -346,6 +346,8 @@ void Client::registerLuaFunctions()
 
     g_lua.bindSingletonFunction("g_game", "getMaxPreWalkingSteps", &Game::getMaxPreWalkingSteps, &g_game);
     g_lua.bindSingletonFunction("g_game", "setMaxPreWalkingSteps", &Game::setMaxPreWalkingSteps, &g_game);
+    g_lua.bindSingletonFunction("g_game", "setEffectTicksPerFrame", &Game::setEffectTicksPerFrame, &g_game);
+    g_lua.bindSingletonFunction("g_game", "getEffectTicksPerFrame", &Game::getEffectTicksPerFrame, &g_game);
     g_lua.bindSingletonFunction("g_game", "ignoreServerDirection", &Game::ignoreServerDirection, &g_game);
     g_lua.bindSingletonFunction("g_game", "showRealDirection", &Game::showRealDirection, &g_game);
     g_lua.bindSingletonFunction("g_game", "enableTileThingLuaCallback", &Game::enableTileThingLuaCallback, &g_game);


### PR DESCRIPTION
## Summary
- add `effectsSpeed` option defaulting to 75ms
- expose `Effect.setTicksPerFrame` in Lua and apply the setting when changed
- revert fade UI helpers to constant timing
- make effects.cpp use configurable ticks per frame

## Testing
- `cmake . -DCMAKE_BUILD_TYPE=Release` *(fails: Could NOT find LuaJIT; Unable to find the requested Boost libraries)*

------
https://chatgpt.com/codex/tasks/task_e_688a473b7710832286fca88006082ea7